### PR TITLE
Fix #172: remove spaces and control characters (newline) from secret

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -82,7 +82,7 @@ object CiReleasePlugin extends AutoPlugin {
     val importCommand =
       if (gpgVersion < 2L) "--import"
       else "--batch --import"
-    val secret = sys.env("PGP_SECRET")
+    val secret = sys.env("PGP_SECRET").filter(_ > ' ') //remove control characters and space from secret
     if (isAzure) {
       // base64 encoded gpg secrets are too large for Azure variables but
       // they fit within the 4k limit when compressed.


### PR DESCRIPTION
In windows copying the secret from console (to the GitHub key) may lead to added newlines/spaces that are not part of the base64 secret. This PR avoids this issue by filtering them out.
