### PR TITLE
Add warning about additional % character in zsh and fish

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,6 +227,9 @@ gpg --armor --export-secret-keys $LONG_ID | base64 | xclip
 gpg --armor --export-secret-keys %LONG_ID% | openssl base64
 ```
 
+*Notice: If you will try to display base64 encoded string in the termianl like zsh or fish 
+they might include additional `%` character at the end of the output to indicate end of the content.
+
 - `SONATYPE_PASSWORD`: The password you use to log into
   https://s01.oss.sonatype.org/ (or https://oss.sonatype.org/ if your Sonatype
   account was created before February 2021). Alternatively, the password part of

--- a/readme.md
+++ b/readme.md
@@ -227,9 +227,8 @@ gpg --armor --export-secret-keys $LONG_ID | base64 | xclip
 gpg --armor --export-secret-keys %LONG_ID% | openssl base64
 ```
 
-*Notice: If you will try to display base64 encoded string in the termianl like zsh or fish 
-they might include additional `%` character at the end of the output to indicate end of the content.
-
+*If you try to display the base64 encoded string in the terminal, some shells (like zsh or fish)
+may include an additional % character at the end, to mark the end of content which was not terminated by a newline character. This does not indicate a problem.*
 - `SONATYPE_PASSWORD`: The password you use to log into
   https://s01.oss.sonatype.org/ (or https://oss.sonatype.org/ if your Sonatype
   account was created before February 2021). Alternatively, the password part of


### PR DESCRIPTION
This closes #226 

Wile trying to find a solution to that I figured out that `zsh` will only add that character when **displaying** something which doesn't end with a new line (obvious, I know :facepalm:). Processing something which doesn't end with a new line won't add `%`. That means instructions are totally correct as piping base64 output to either `xclip` or `xsel` won't cause the `%` to appear. 

Because of that there is nothing much to add to the instructions apart from maybe a small warning.
