### PR TITLE
Update sbt-git to 2.0.0 (with required changes)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val plugin = project
     moduleName := "sbt-ci-release",
     sbtVersion in pluginCrossBuild := "1.0.4",
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1"),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2"),
+    addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0"),
     addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
   )

--- a/build.sbt
+++ b/build.sbt
@@ -18,13 +18,13 @@ inThisBuild(
 
 onLoadMessage := s"Welcome to sbt-ci-release ${version.value}"
 
-skip in publish := true // don't publish the root project
+publish / skip := true // don't publish the root project
 
 lazy val plugin = project
   .enablePlugins(SbtPlugin)
   .settings(
     moduleName := "sbt-ci-release",
-    sbtVersion in pluginCrossBuild := "1.0.4",
+    pluginCrossBuild / sbtVersion := "1.0.4",
     addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0"),
     addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10"),

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -1,7 +1,7 @@
 package com.geirsson
 
-import com.typesafe.sbt.GitPlugin
-import com.typesafe.sbt.SbtGit.GitKeys
+import com.github.sbt.git.GitPlugin
+import com.github.sbt.git.SbtGit.GitKeys
 import com.jsuereth.sbtpgp.SbtPgp
 import com.jsuereth.sbtpgp.SbtPgp.autoImport._
 import java.nio.file.Files

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ unmanagedSourceDirectories.in(Compile) +=
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")


### PR DESCRIPTION
Updates com.typesafe.sbt:sbt-git from 1.0.2 to 2.0.0.

I extended #235 with the requisite changes to get the build to pass, as well as fixed the old "in" syntax from build.sbt.

Have a fantastic day writing Scala!