### PR TITLE
Fail the whole process if any of the mid-step pipes fail

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -1,9 +1,11 @@
 package com.geirsson
 
+import com.geirsson.PipeFail.PipeFailOps
 import com.typesafe.sbt.GitPlugin
 import com.typesafe.sbt.SbtGit.GitKeys
 import com.jsuereth.sbtpgp.SbtPgp
 import com.jsuereth.sbtpgp.SbtPgp.autoImport._
+
 import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.charset.StandardCharsets
@@ -14,6 +16,7 @@ import sbt._
 import sbt.plugins.JvmPlugin
 import sbtdynver.DynVerPlugin
 import sbtdynver.DynVerPlugin.autoImport._
+
 import scala.deprecated
 import scala.sys.process._
 import scala.util.control.NonFatal
@@ -76,7 +79,7 @@ object CiReleasePlugin extends AutoPlugin {
     val TaggedVersion = """(\d{1,14})([\.\d{1,14}]*)((?:-\w+)*)""".r
     val gpgVersion: Long = versionLine.split(" ").last match {
       case TaggedVersion(m, _, _) => m.toLong
-      case _                         => 0L
+      case _                      => 0L
     }
     // https://dev.gnupg.org/T2313
     val importCommand =
@@ -90,7 +93,7 @@ object CiReleasePlugin extends AutoPlugin {
       s"unzip gpg.zip".!
       s"gpg $importCommand gpg.key".!
     } else {
-      (s"echo $secret" #| "base64 --decode" #| s"gpg $importCommand").!
+      (s"echo $secret" #|! "base64 --decode" #|! s"gpg $importCommand").!
     }
   }
 
@@ -108,9 +111,10 @@ object CiReleasePlugin extends AutoPlugin {
       case None =>
         import scala.sys.process._
         val identifier = """([^\/]+?)"""
-        val GitHubHttps = s"https://github.com/$identifier/$identifier(?:\\.git)?".r
-        val GitHubGit   = s"git://github.com:$identifier/$identifier(?:\\.git)?".r
-        val GitHubSsh   = s"git@github.com:$identifier/$identifier(?:\\.git)?".r
+        val GitHubHttps =
+          s"https://github.com/$identifier/$identifier(?:\\.git)?".r
+        val GitHubGit = s"git://github.com:$identifier/$identifier(?:\\.git)?".r
+        val GitHubSsh = s"git@github.com:$identifier/$identifier(?:\\.git)?".r
         try {
           val remote = List("git", "ls-remote", "--get-url", "origin").!!.trim()
           remote match {

--- a/plugin/src/main/scala/com/geirsson/PipeFail.scala
+++ b/plugin/src/main/scala/com/geirsson/PipeFail.scala
@@ -1,0 +1,35 @@
+package com.geirsson
+
+import java.io.ByteArrayInputStream
+import scala.sys.process.{ProcessBuilder, ProcessLogger}
+import scala.util.{Failure, Success, Try}
+
+object PipeFail {
+  implicit class PipeFailOps[R](p1: R) {
+    @volatile
+    private var error: Option[String] = None
+
+    def #|!(p2: R)(implicit ev: R => ProcessBuilder): ProcessBuilder = {
+      val logger = new ProcessLogger {
+        override def out(s: => String): Unit = ()
+
+        override def err(s: => String): Unit = {
+          error = Some(s)
+        }
+
+        override def buffer[T](f: => T): T = f
+      }
+      Try(p1.!!(logger)).map(result =>
+        (p2 #< new ByteArrayInputStream(result.getBytes))
+      ) match {
+        case Failure(exception) =>
+          error match {
+            case Some(errorMessageFromPipe) =>
+              throw new RuntimeException(errorMessageFromPipe, exception)
+            case None => throw exception
+          }
+        case Success(value) => value
+      }
+    }
+  }
+}


### PR DESCRIPTION
This fixes #227 

Please note that the sbt-ci-release will still continue if the last process from the chain fails.

In our case:
`(s"echo $secret" #|! "base64 --decode" #|! s"gpg $importCommand").!`

`s"gpg $importCommand"` can fail and we won't notice it. 

Let me know if you would like me to address that in this PR or in a separate one.