### PR TITLE
Update the instructions for sonatypeCredentialHost

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,7 +126,7 @@ If your sonatype account is new (created after Feb 2021), then the default serve
 location inherited from the the `sbt-sonatype` plugin will not work, and you should
 also include the following overrides in your publishing settings
 ```scala
-sonatypeCredentialHost := "s01.oss.sonatype.org"
+ThisBuild / sonatypeCredentialHost := "s01.oss.sonatype.org"
 sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
 ```
 


### PR DESCRIPTION
Without `ThisBuild / `, the setting would only be applied to the top-level project, which breaks publishing in multi-project builds.

See this pull request: https://github.com/xerial/sbt-sonatype/pull/242

And this report: https://github.com/sbt/sbt-ci-release/issues/173#issuecomment-886082868

I had the exact same issue as kflorence, and it was fixed by adding the ThisBuild part.