### PR TITLE
Cache sbt build artifacts across CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,5 +7,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - uses: olafurpg/setup-scala@v14
+    - uses: actions/setup-java@v3
+      with:
+        distribution: temurin
+        java-version: 8
+        cache: sbt
     - run: sbt compile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v14
+      - uses: actions/setup-scala@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
Changed step to install Java to actions/setup-java instead of olafurpg/setup-scala, switch to the temurin distribution, and enable sbt caching.

The main motivation for this change is that the workflow `release.yml` is linked as an example from the documentation. I think it is important to have it up to date and efficient.