### PR TITLE
update secret key export doc (macos)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -235,7 +235,7 @@ Add the following secrets:
 
 ```
 # macOS
-gpg --armor --export-secret-keys $LONG_ID | base64 | pbcopy
+gpg --armor --export-secret-keys $LONG_ID | base64 -w0 | pbcopy
 # Ubuntu (assuming GNU base64)
 gpg --armor --export-secret-keys $LONG_ID | base64 -w0 | xclip
 # Arch


### PR DESCRIPTION
I've been using these instructions for over year but recently I have found that when I export the gpg private key on my Mac that GitHub CI publish tasks fail at the base64 decode stage.

Adding -w0 when exporting the key fixes this. The Linux instructions include the `-w0` already.