### PR TITLE
Update sbt-sonatype to 3.11.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,5 +28,5 @@ lazy val plugin = project
     addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1"),
-    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
+    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.2")
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,4 @@ unmanagedSourceDirectories.in(Compile) +=
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.11.2")


### PR DESCRIPTION
This sbt-sonatype version removes zio dependancy from the sonatype central support implementation