### PR TITLE
Use consistent ordering of CI tool environment variables

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -42,17 +42,17 @@ object CiReleasePlugin extends AutoPlugin {
         .exists(_.startsWith("refs/tags"))
   def releaseTag: String =
     Option(System.getenv("TRAVIS_TAG"))
-      .orElse(Option(System.getenv("BUILD_SOURCEBRANCH")))
-      .orElse(Option(System.getenv("GITHUB_REF")))
       .orElse(Option(System.getenv("CIRCLE_TAG")))
       .orElse(Option(System.getenv("CI_COMMIT_TAG")))
+      .orElse(Option(System.getenv("BUILD_SOURCEBRANCH")))
+      .orElse(Option(System.getenv("GITHUB_REF")))
       .getOrElse("<unknown>")
   def currentBranch: String =
     Option(System.getenv("TRAVIS_BRANCH"))
-      .orElse(Option(System.getenv("BUILD_SOURCEBRANCH")))
-      .orElse(Option(System.getenv("GITHUB_REF")))
       .orElse(Option(System.getenv("CIRCLE_BRANCH")))
       .orElse(Option(System.getenv("CI_COMMIT_BRANCH")))
+      .orElse(Option(System.getenv("BUILD_SOURCEBRANCH")))
+      .orElse(Option(System.getenv("GITHUB_REF")))
       .getOrElse("<unknown>")
 
   @deprecated("Deprecated, please use isSecure", "1.4.32")


### PR DESCRIPTION
This arguably shouldn't matter, but the order that the environment variables set by different CI tools were checked was inconsistent.