### PR TITLE
chore: adding sonatype central faq link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ Let's get started!
   - [Travis](#travis)
 - [Git](#git)
 - [FAQ](#faq)
+  - [How do I publish to Sonatype Central?](#how-do-i-publish-to-sonatype-central)
   - [How do I disable publishing in certain projects?](#how-do-i-disable-publishing-in-certain-projects)
   - [How do I publish cross-built projects?](#how-do-i-publish-cross-built-projects)
   - [How do I publish cross-built Scala.js projects?](#how-do-i-publish-cross-built-scalajs-projects)


### PR DESCRIPTION
## Description

The beginning of the readme did not contain a link to the Sonatype Central FAQ entry, as it does to all other entries. This PR adds said link.