### PR TITLE
Prep for sbt 2, update to slash syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+lazy val scala212 = "2.12.20"
+lazy val scala3 = "3.3.4"
+
 inThisBuild(
   List(
     organization := "com.github.sbt",
@@ -12,7 +15,8 @@ inThisBuild(
         "olafurpg@gmail.com",
         url("https://geirsson.com")
       )
-    )
+    ),
+    crossScalaVersions := Seq(scala212)
   )
 )
 
@@ -24,7 +28,12 @@ lazy val plugin = project
   .enablePlugins(SbtPlugin)
   .settings(
     moduleName := "sbt-ci-release",
-    pluginCrossBuild / sbtVersion := "1.0.4",
+    (pluginCrossBuild / sbtVersion) := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.5.8"
+        case _      => "2.0.0-M2"
+      }
+    },
     addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1"),

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -130,7 +130,7 @@ object CiReleasePlugin extends AutoPlugin {
   )
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = List(
-    publishArtifact.in(Test) := false,
+    (Test / publishArtifact) := false,
     publishMavenStyle := true,
     commands += Command.command("ci-release") { currentState =>
       val shouldDeployToSonatypeCentral = isDeploySetToSonatypeCentral(currentState)
@@ -200,7 +200,7 @@ object CiReleasePlugin extends AutoPlugin {
   )
 
   def isDeploySetToSonatypeCentral(state: State): Boolean = {
-    sonatypeCredentialHost.in(ThisBuild).get(Project.extract(state).structure.data) match {
+    (ThisBuild / sonatypeCredentialHost).get(Project.extract(state).structure.data) match {
       case Some(value) if value == Sonatype.sonatypeCentralHost => {
         true
       }
@@ -209,7 +209,7 @@ object CiReleasePlugin extends AutoPlugin {
   }
 
   def isSnapshotVersion(state: State): Boolean = {
-    version.in(ThisBuild).get(Project.extract(state).structure.data) match {
+    (ThisBuild / version).get(Project.extract(state).structure.data) match {
       case Some(v) => v.endsWith("-SNAPSHOT")
       case None    => throw new NoSuchFieldError("version")
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-unmanagedSourceDirectories.in(Compile) +=
-  baseDirectory.in(ThisBuild).value.getParentFile /
+Compile / unmanagedSourceDirectories +=
+  (ThisBuild / baseDirectory).value.getParentFile /
     "plugin" / "src" / "main" / "scala"
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.1")


### PR DESCRIPTION
* Adds initial code for crossbuild (but not using it yet)
* Update a few locations where `.in()` was being used. Eliminates deprecation warnings.