### PR TITLE
Implement back publishing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
         java-version: 8
         cache: sbt
     - uses: sbt/setup-sbt@v1
-    - run: sbt +compile
+    - run: sbt +test

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val plugin = project
         case _      => "2.0.0-M2"
       }
     },
+    libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test,
     addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.0"),

--- a/plugin/src/test/scala/com/geirsson/CiReleaseTest.scala
+++ b/plugin/src/test/scala/com/geirsson/CiReleaseTest.scala
@@ -1,0 +1,47 @@
+package com.geirsson
+
+import CiReleasePlugin.{ backPubVersionToCommand, dropBackPubCommand }
+
+class CiReleaseTest extends munit.FunSuite {
+  val expectedVer = "1.1.0"
+
+  test("Normal version default") {
+    assertEquals(backPubVersionToCommand("1.1.0"), "+publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0"), expectedVer)
+  }
+
+  test("Command starting with number is assumed to be a cross version") {
+    assertEquals(backPubVersionToCommand("1.1.0@2.12.20"), ";++2.12.20!;publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@2.12.20"), expectedVer)
+
+    assertEquals(backPubVersionToCommand("1.1.0@3.x"), ";++3.x;publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@3.x"), expectedVer)
+  }
+
+  test("Non-number is treated as an alternative publish command") {
+    assertEquals(backPubVersionToCommand("1.1.0@foo/publishSigned"), "foo/publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@foo/publishSigned"), expectedVer)
+
+    assertEquals(backPubVersionToCommand("1.1.0@+foo/publishSigned"), "+foo/publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@+foo/publishSigned"), expectedVer)
+  }
+
+  test("Commands can be chained") {
+    assertEquals(backPubVersionToCommand("1.1.0@2.12.20@foo/publishSigned"), ";++2.12.20!;foo/publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@2.12.20@foo/publishSigned"), expectedVer)
+
+    assertEquals(backPubVersionToCommand("1.1.0@foo/something@bar/publishSigned"), ";foo/something;bar/publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@foo/something@bar/publishSigned"), expectedVer)
+  }
+
+  test("Treat # as comments") {
+    assertEquals(backPubVersionToCommand("1.1.0#comment"), "+publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0#comment"), expectedVer)
+
+    assertEquals(backPubVersionToCommand("1.1.0@2.12.20#comment"), ";++2.12.20!;publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@2.12.20#comment"), expectedVer)
+
+    assertEquals(backPubVersionToCommand("1.1.0@3.x#comment"), ";++3.x;publishSigned")
+    assertEquals(dropBackPubCommand("1.1.0@3.x#comment"), expectedVer)
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -356,6 +356,56 @@ page will look like this:
 
 Enjoy 👌
 
+### Back-publishing support
+
+sbt-ci-release implements a mini-DSL for the Git tag for back publishing purpose, which is useful if you maintain a compiler plugin, library for Scala Native, or an sbt plugin during 2.x migration etc.
+
+```
+v1.2.3[@3.x|@2.n.x|@a.b.c][@command][#comment]
+```
+
+- `#` is used for comments, which is useful if you need to use the same command multiple times
+- `@3.x` expands to `++3.x`, and if no other commands follow, `;++3.x;publishSigned`
+- `@2.13.x` expands to `++2.13.x`, and if no other commands follow, `;++2.13.x;publishSigned`
+- Other commands such as `@foo/publishSigned` expands to `foo/publishSigned`
+
+#### Case 1: Publish all subprojects for Scala 2.13.15
+
+`v1.2.3@2.13.15`
+
+#### Case 2: Publish all subprojects for Scala 3.x
+
+`v1.2.3@3.x`. Optionally we can add a comment: `v1.2.3@3.x#comment`.
+
+We can use this to back publish sbt 2.x plugins.
+
+1. Branch off of `v1.2.3` to create `release/1.2.3` branch, and send a PR to update sbt version
+2. Tag the brach to `v1.2.3@3.x#sbt2.0.0-Mn`
+
+#### Case 3: Publish some subprojects for Scala 2.13.15
+
+`v1.2.3@2.13.15@foo/publishSigned`
+
+You can create a subproject to aggregate 2 or more subprojects.
+
+#### Case 4: Publish some subprojects for supported Scala versions
+
+`v1.2.3@+foo_native/publishSigned#comment`
+
+1. Branch off of `v1.2.3` to create `release/1.2.3` branch, and send a PR to update the Scala Native version.
+2. Tag the branch to `v1.2.3@+foo_native/publishSigned#native0.5`
+
+#### Case 5: Minimize the use of command
+
+`v1.2.3#unique_comment`, for example `v1.2.3#native0.5_3`
+
+If you prefer to keep most of the information in a git branch instead, you can just use the comment functionality.
+
+1. Branch off of `v1.2.3` to create `release/1.2.3` branch, and send a PR to:
+   a. Update appropriate dependency (sbt, Scala Native etc)
+   b. Modify the `CI_RELEASE` environment variable to encode the actions you want to take, like `;++3.x;foo_native/publishSigned`. For GitHub Actions, it would be in `.github/workflows/release.yml`
+2. Tag the branch to `v1.2.3#unique_comment`. For record keeping, encode the version you're trying to back publishing for e.g. `v1.2.3#native0.5_3`
+
 ## FAQ
 
 ### How do I publish to Sonatype Central?


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-ci-release/issues/102
Ref https://github.com/scalameta/metals/pull/3557
Ref https://github.com/typelevel/kind-projector/pull/206
Ref https://github.com/scala/scala-parser-combinators/blob/d2e6685145ca4a9298c3d2ac0bde5ccf090f5d99/build.sh#L13-L15

## Problem
For plugin code, like sbt plugins and Scala compiler plugin, and even normal libraries, it's common for the maintainers to want to back publish the current code base against a new version of Scala (or sbt, Scala Native etc) instead of bumping the version.

The current "bump the version" approach effectively pushes the work of figuring out the correct patch version number to the end users. In addition, if the plugin or the library does not cross publish all variants, then the end user might need to figure out different patch version to use effectively the same code.

## Solution
This implements a mini DSL for tag:

```bash
version[@command|@a.b.c|@a.b."x"][#comment]
```

, which allows plugin authors to back publish a code base. A back-publish tag is split via `@` character, and uses `#` to denote comments. The comment is useful when multiple tags must be made pointing to the same version, which might be needed to recover from failures or for sbt plugin migration.

- `@a.b."x"` for example `@3.x` expands to `;++3.x;publishSigned`
- `@a.b.c` for example `@2.12.20` expands to `;++2.12.20!;publishSigned`
- `@command` for example `@foo/publishSigned` expands to `foo/publishSigned`

For example, to back publish sbt-pgp plugin 2.3.0, we will tag `2.3.0@3.x#sbt-2.0.0-M3`.
