### PR TITLE
Remove sks-keyservers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -192,16 +192,13 @@ or run:
 ```bash
 # macOS
 gpg --keyserver hkp://keyserver.ubuntu.com --send-key $LONG_ID && \
- gpg --keyserver hkp://pgp.mit.edu --send-key $LONG_ID && \
- gpg --keyserver hkp://pool.sks-keyservers.net --send-key $LONG_ID
+ gpg --keyserver hkp://pgp.mit.edu --send-key $LONG_ID
 # linux
 gpg --keyserver hkp://keyserver.ubuntu.com --send-key $LONG_ID && \
- gpg --keyserver hkp://pgp.mit.edu --send-key $LONG_ID && \
- gpg --keyserver hkp://pool.sks-keyservers.net --send-key $LONG_ID
+ gpg --keyserver hkp://pgp.mit.edu --send-key $LONG_ID
 # Windows
 gpg --keyserver hkp://keyserver.ubuntu.com --send-key %LONG_ID% && \
- gpg --keyserver hkp://pgp.mit.edu --send-key %LONG_ID% && \
- gpg --keyserver hkp://pool.sks-keyservers.net --send-key %LONG_ID%
+ gpg --keyserver hkp://pgp.mit.edu --send-key %LONG_ID%
 ```
 
 ## Secrets


### PR DESCRIPTION
I think the SKS Keyserver Network has been gone for a number of years already.