### PR TITLE
Scope version to project

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -142,8 +142,7 @@ object CiReleasePlugin extends AutoPlugin {
         case Some(cmd) => cmd
         case None      => backPubVersionToCommand(v)
       }
-    },
-    version ~= dropBackPubCommand
+    }
   )
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = List(
@@ -219,6 +218,7 @@ object CiReleasePlugin extends AutoPlugin {
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = List(
+    version ~= dropBackPubCommand,
     publishConfiguration :=
       publishConfiguration.value.withOverwrite(true),
     publishLocalConfiguration :=


### PR DESCRIPTION
## Problem
Back publishing doesn't work because `version`
is scoped to build-level but GitPlugin has an entry at project level.

## Solution
This moves version to project level.