### PR TITLE
Be more dynver-aware while dropping tag commands

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -143,7 +143,19 @@ object CiReleasePlugin extends AutoPlugin {
         case None      => backPubVersionToCommand(v)
       }
     },
-    version ~= dropBackPubCommand
+    version := {
+      val v = version.value
+      dynverGitDescribeOutput.value match {
+        case Some(gitDescribe) =>
+          val tagVersion = gitDescribe.ref.dropPrefix
+          if (gitDescribe.isCleanAfterTag) {
+            dropBackPubCommand(v)
+          } else if (v.startsWith(tagVersion)) {
+            dropBackPubCommand(tagVersion) + v.drop(tagVersion.size)
+          } else v
+        case _ => v
+      }
+    }
   )
 
   override lazy val globalSettings: Seq[Def.Setting[_]] = List(


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-ci-release/issues/357

## Problem
Currently the dropBackPubCommand is too aggressive in dropping everything after at-sign, which ends up dropping dynver suffixes.

## Solution
This implements dynver-aware dropping.