### PR TITLE
Publish using Central Portal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,5 +44,5 @@ lazy val plugin = project
     addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0"),
     addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1"),
-    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
+    publishTo := sonatypePublishToBundle.value
   )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-ci-release/issues/344

This drops sbt-sonatype, and uses sbt 1.11.0-RC1 to publish to Central Portal.
