### PR TITLE
fix: SNAPSHOT publishing, take 3

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -183,7 +183,7 @@ object CiReleasePlugin extends AutoPlugin {
             reloadKeyFiles ::
               sys.env.getOrElse("CI_CLEAN", "; clean") ::
               publishCommand ::
-              sys.env.getOrElse("CI_SNAPSHOT_RELEASE", "sonaRelease") ::
+              sys.env.getOrElse("CI_SNAPSHOT_RELEASE", "version") ::
               currentState
           } else {
             // Happens when a tag is pushed right after merge causing the main branch
@@ -219,9 +219,13 @@ object CiReleasePlugin extends AutoPlugin {
     publishTo := {
       val orig = (ThisBuild / publishTo).value
       (orig, localStaging.?.value) match {
-        case (Some(r), _)          => orig
-        case (None, Some(staging)) => staging
-        case _                     => orig
+        case (Some(r), _) => orig
+        case (None, None) => orig
+        case (None, Some(staging)) =>
+          val centralSnapshots =
+            "https://central.sonatype.com/repository/maven-snapshots/"
+          if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+          else staging
       }
     }
   )


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-ci-release/issues/344

## Problem
Currently snapshot publishing tries to use the Central Portal, but there's actually a separate endpoint we should use.

## Solution
This fixes that.