### PR TITLE
fix: Run +publish on SNAPSHOT

### DIFF
--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -192,8 +192,7 @@ object CiReleasePlugin extends AutoPlugin {
             reloadKeyFiles ::
               sys.env.getOrElse("CI_CLEAN", "; clean") ::
               // workaround for *.asc.sha1 not being allowed
-              "publish" ::
-              sys.env.getOrElse("CI_SNAPSHOT_RELEASE", "version") ::
+              sys.env.getOrElse("CI_SNAPSHOT_RELEASE", "+publish") ::
               currentState
           } else {
             // Happens when a tag is pushed right after merge causing the main branch


### PR DESCRIPTION
Fixes https://github.com/sbt/sbt-ci-release/issues/380

## Problem
For SNAPSHOT sbt-ci-release 1.11.0 runs publish,
which doesn't cross publish.

## Solution
This runs +publish.