### PR TITLE
Remove totally unnecessary transitive sbt-git dependency (!)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,6 +42,5 @@ lazy val plugin = project
     },
     libraryDependencies += "org.scalameta" %% "munit" % "1.3.3" % Test,
     addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1"),
-    addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0"),
     addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
   )

--- a/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
+++ b/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala
@@ -2,8 +2,6 @@ package com.geirsson
 
 import com.geirsson.PipeFail.PipeFailOps
 import PluginCompat.*
-import com.github.sbt.git.GitPlugin
-import com.github.sbt.git.SbtGit.GitKeys
 import com.jsuereth.sbtpgp.SbtPgp
 import com.jsuereth.sbtpgp.SbtPgp.autoImport.*
 
@@ -26,7 +24,7 @@ object CiReleasePlugin extends AutoPlugin {
 
   override def trigger = allRequirements
   override def requires =
-    JvmPlugin && SbtPgp && DynVerPlugin && GitPlugin
+    JvmPlugin && SbtPgp && DynVerPlugin
 
   def isSecure: Boolean =
     System.getenv("TRAVIS_SECURE_ENV_VARS") == "true" ||

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,5 @@ Compile / unmanagedSourceDirectories +=
   (ThisBuild / baseDirectory).value.getParentFile /
     "plugin" / "src" / "main" / "scala-2.12"
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
-addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,6 @@ By installing `sbt-ci-release` the following sbt plugins are also brought in:
   based on your git history
 - [sbt-pgp](https://github.com/sbt/sbt-pgp): to cryptographically sign the
   artifacts before publishing
-- [sbt-git](https://github.com/sbt/sbt-git): to automatically populate `scmInfo`
 
 Make sure `build.sbt` does not define any of the following settings
 
@@ -395,7 +394,7 @@ your environment.
 Yes, but the plugin is not released for sbt 0.13. The plugin source code is a
 single file which you can copy-paste into `project/CiReleasePlugin.scala` of
 your 0.13 build. Make sure you also
-`addSbtPlugin(sbt-dynver + sbt-sonatype + sbt-gpg + sbt-git)`.
+`addSbtPlugin(sbt-dynver + sbt-sonatype + sbt-gpg)`.
 
 ### How do I publish sbt plugins?
 


### PR DESCRIPTION
sbt-ci-release no longer uses sbt-git APIs directly. The `scmInfo` fallback shells out to `git ls-remote --get-url origin`, and versioning continues to come from sbt-dynver (which does NOT use sbt-git).

This also removes sbt-git from the local meta-build and updates the README so users are not told that sbt-git is brought in transitively.

> [!NOTE]  
>  Just having sbt-git on the classpath causes all those issues listed in https://github.com/sbt/sbt-git/pull/382 when people are inside a linked worktree. Just having sbt-git on the plugin classpath is enough to activate its settings. Then its build settings evaluate Git metadata, including `ThisBuild / gitUncommittedChanges := gitReader.value.withGit(_.hasUncommittedChanges)`
> With current released sbt-git/JGit 5, that read path uses JGit by default. In a linked worktree, JGit 5 cannot resolve the worktree correctly and throws: `NoWorkTreeException: Bare Repository has neither a working tree, nor an index`
> So the chain is:
>  sbt-ci-release depends on sbt-git
>  -> sbt-git is on plugin classpath
>  -> GitPlugin auto-enables
>  -> gitUncommittedChanges gets evaluated during setting loading
>  -> JGit 5 status fails in linked worktree
